### PR TITLE
Override #can with #cannot (specs included)

### DIFF
--- a/corral.gemspec
+++ b/corral.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split($/)
   s.require_paths = ["lib"]
   s.add_runtime_dependency "rails", "~> 5.0"
+  s.add_development_dependency "rspec"
 end

--- a/lib/corral/ability.rb
+++ b/lib/corral/ability.rb
@@ -31,11 +31,13 @@ module Corral
       rule_for(subject).add_grant(action, block)
     end
 
-    # Inverse of #can.
+    # Adds a denying-access rule. Overrides previous #can definitions.
     #
-    # @see #can
-    def cannot(action, subject, &block)
-      rule_for(subject).add_deny(action, block)
+    # @param action [Symbol] The action, represented as a symbol.
+    # @param subject [Object] The subject.
+    def cannot(action, subject)
+      raise ArgumentError, '#cannot does not support granular matching by block.' if block_given?
+      rule_for(subject).add_deny(action)
     end
 
     # Allow the object to perform any action on any subject.
@@ -76,7 +78,7 @@ module Corral
     def lookup_rule(subject)
       case subject
       when Symbol, Module
-        r = subjects[subject] || subjects[:all] || NullRule
+        subjects[subject] || subjects[:all] || NullRule
       else
         subjects[subject.class] || NullRule
       end

--- a/lib/corral/rule.rb
+++ b/lib/corral/rule.rb
@@ -14,12 +14,12 @@ module Corral
       @actions[action] = (block || true)
     end
 
-    # Add a denying ACL for a particular action.
+    # Add a denying ACL for a particular action, which overrides
+    # granting ACLs, including :manage.
     #
     # @param action [symbol] The action.
-    # @param block An optional block for granularity.
-    def add_deny(action, block)
-      @actions[action] = (block || false)
+    def add_deny(action)
+      @actions[action] = false
     end
 
     # Return whether or not an object can perform a particular action on a subject
@@ -28,6 +28,9 @@ module Corral
     # @param args [Hash] Variable arguments for more granular matching.
     # @return [Boolean] True or false.
     def authorized?(action, subject, args)
+      deny = @actions[action]
+      return false if deny == false
+
       block = @actions[:manage] || @actions[action]
       return false unless block
       return true if block == true

--- a/spec/lib/ability_spec.rb
+++ b/spec/lib/ability_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+class AbilityModel
+  include Corral::Ability
+end
+class ActionSubject; end
+
+RSpec.describe Corral::Ability do
+  subject { AbilityModel.new }
+
+  describe '#allow_anything!' do
+    it 'allows any action' do
+      subject.allow_anything!
+      expect(subject.can? :perform_action, ActionSubject).to be_truthy
+    end
+  end
+
+  describe '#can (#can?)' do
+    it 'allows permitted actions' do
+      subject.can :perform_action, ActionSubject
+      expect(subject.can? :perform_action, ActionSubject).to be_truthy
+    end
+
+    it 'denies anything that is not permitted' do
+      expect(subject.can? :perform_action, ActionSubject).to be_falsey
+    end
+
+    it 'allows actions to be whitelisted with :manage' do
+      subject.can :manage, ActionSubject
+      expect(subject.can? :manage, ActionSubject).to be_truthy
+      expect(subject.can? :perform_action, ActionSubject).to be_truthy
+    end
+
+    context 'with blocks' do
+      it 'allows access to be specified dynamically' do
+        subject.can(:perform_action, ActionSubject) { @state }
+
+        @state = false
+        expect(subject.can? :perform_action, ActionSubject).to be_falsey
+        @state = true
+        expect(subject.can? :perform_action, ActionSubject).to be_truthy
+      end
+
+      it 'passes the subject to the block' do
+        subject.can :perform_action, ActionSubject do |action_subject|
+          expect(action_subject).to be ActionSubject
+        end
+        subject.can? :perform_action, ActionSubject
+      end
+
+      it 'accepts an instance of the subject to be passed to the block' do
+        instance = ActionSubject.new
+        subject.can :perform_action, ActionSubject do |action_subject|
+          expect(action_subject).to be instance
+        end
+        subject.can? :perform_action, instance
+      end
+
+      it 'accepts arbitrary values to be passed to the block' do
+        value1, value2, value3 = [1, 'hello', true]
+        subject.can :perform_action, ActionSubject do |_subject, v1, v2, v3|
+          expect(v1).to eq value1
+          expect(v2).to eq value2
+          expect(v3).to eq value3
+        end
+        subject.can? :perform_action, ActionSubject, value1, value2, value3
+      end
+    end
+  end
+
+  describe '#cannot' do
+    context 'specified after #can' do
+      it 'overrides single definitions' do
+        subject.can :perform_action, ActionSubject
+        subject.cannot :perform_action, ActionSubject
+        expect(subject.can? :perform_action, ActionSubject).to be_falsey
+      end
+
+      it 'overrides :manage' do
+        subject.can :manage, ActionSubject
+        subject.cannot :destroy, ActionSubject
+
+        expect(subject.can? :manage, ActionSubject).to be_truthy
+        expect(subject.can? :perform_action, ActionSubject).to be_truthy
+        expect(subject.can? :destroy, ActionSubject).to be_falsey
+      end
+    end
+
+    context 'specified after #allow_anything!' do
+      it 'does not restrict access' do
+        subject.allow_anything!
+        subject.cannot :perform_action, ActionSubject
+
+        expect(subject.can? :perform_action, ActionSubject).to be_truthy
+      end
+    end
+
+    it 'does not accept blocks' do
+      expect { subject.cannot(:manage, ActionSubject) { true } }.to raise_error(ArgumentError, '#cannot does not support granular matching by block.')
+    end
+
+    it 'does not accept additional values' do
+      expect { subject.cannot(:manage, ActionSubject, 'value') }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'corral'
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.color = true
+  config.fail_fast = true
+end


### PR DESCRIPTION
We have found that the inability to override `#can` definitions imposes a significant restriction on how we partition access between users. It renders `:manage` impractical and forces us to resort to unreasonable levels of code repetition.

The current implementation of `#cannot` is able to override single declarations, however that is rarely applicable given that `#can` supports granular access control with blocks. Furthermore, the behavior of `#cannot` itself with blocks is downright misleading because it does not negate the return value, hence acting like an unexpected alias of `#can`.

My pull request removes support for blocks in `#cannot` and enables it to override `:manage` declarations. I have also added basic behavior specifications with RSpec.